### PR TITLE
fix raise file not found error if cbz file already exist

### DIFF
--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -166,6 +166,9 @@ def generate_main_html(output_dir='./'):
 def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False, write_comic_info=True, move_to_folder=False):
     if doujinshi_obj is not None:
         doujinshi_dir = os.path.join(output_dir, doujinshi_obj.filename)
+        if os.path.exists(doujinshi_dir+".cbz"):
+            logger.warning(f'Comic Book CBZ file exists, skip "{doujinshi_dir}"')
+            return
         if write_comic_info:
             serialize_comic_xml(doujinshi_obj, doujinshi_dir)
         cbz_filename = os.path.join(os.path.join(doujinshi_dir, '..'), f'{doujinshi_obj.filename}.cbz')


### PR DESCRIPTION
Personally found out there was an error when I re-downloaded manga as cbz file. Error occured when origin-dir not found while cbz files exist. Fix it by skipping remaining process of generate_cbz function if exists.

![Screenshot_20240224_230205](https://github.com/myc1ou1d/nhentai/assets/92770704/723d8eb2-3198-4806-a58d-0327361eb616)
